### PR TITLE
Use the path instead of title for suggested download filename.

### DIFF
--- a/gopher/ourutils.c
+++ b/gopher/ourutils.c
@@ -1285,10 +1285,10 @@ Save_file(GopherObj *gs, char *saveto, char *view)
      /* Get the Path and save the base name
       * to use as a default filename.
       */
-     strcpy(Title, basename(GSgetPath(gs)));
+     strncpy(Title, basename(GSgetPath(gs)), 127);
 
      if (saveto == NULL) {
-  	/* It shouldnt ever come here if Secure, but I've noticed calls 
+  	/* It shouldnt ever come here if Secure, but I've noticed calls
      	to this in the code */
   	if (NoShellMode || SecureMode) {
 		CursesErrorMsg(Gtxt("Sorry, you are not allowed to do this", 64));

--- a/gopher/ourutils.c
+++ b/gopher/ourutils.c
@@ -1282,11 +1282,11 @@ Save_file(GopherObj *gs, char *saveto, char *view)
      if (view == NULL || view == "")
 	  return;
 
-     /*** Get the Title ***/
+     /* Get the Path and save the base name
+      * to use as a default filename.
+      */
      strcpy(Title, basename(GSgetPath(gs)));
 
-     /*** Construct a nice default filename ***/
-     
      if (saveto == NULL) {
   	/* It shouldnt ever come here if Secure, but I've noticed calls 
      	to this in the code */

--- a/gopher/ourutils.c
+++ b/gopher/ourutils.c
@@ -1283,7 +1283,7 @@ Save_file(GopherObj *gs, char *saveto, char *view)
 	  return;
 
      /*** Get the Title ***/
-     strcpy(Title, GSgetTitle(gs));
+     strcpy(Title, basename(GSgetPath(gs)));
 
      /*** Construct a nice default filename ***/
      

--- a/gopher/pager.c
+++ b/gopher/pager.c
@@ -173,8 +173,8 @@ PagerTitles(CursesObj *cur, GopherObj *gs, int totalbytes)
      wboldout(stdscr);
 
      fluff_len = 11 + (k_bytes/10);     /* 11 = strlen("_(0k)_100%_"); */
-     if((strlen(GSgetTitle(gs))) <= (COLS-fluff_len)) {
-       waddstr(stdscr, GSgetTitle(gs));
+     if((strlen(basename(GSgetPath(gs)))) <= (COLS-fluff_len)) {
+       waddstr(stdscr, basename(GSgetPath(gs)));
      } else {
        cp = GSgetTitle(gs);
        for(i = 0; i < (COLS-(fluff_len+3)); i++) {


### PR DESCRIPTION
Most (all?) classic Gopher servers would put only the file name in the
title descriptor.  The Gophernicus server will put timestamps and file
sizes there.  Most other Gopher clients will use the path of the
downloaded file run through basename() or some equivalent for a
suggested download filename.  UM Gopher has always used the title
instead.  The effect of this is that when browsing a Gophernicus-running
server using UM Gopher with timestamps and file sizes enabled, you'll
get the timestamp and file size appended to the actual file name for a
suggested download name.

Fixes issue #2