### PR TITLE
fix: fix compilation with GCC 14

### DIFF
--- a/configure
+++ b/configure
@@ -679,7 +679,7 @@ cat > conftest.$ac_ext << EOF
 #line 680 "configure"
 #include "confdefs.h"
 
-main(){return(0);}
+int main(){return(0);}
 EOF
 if { (eval echo configure:685: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext}; then
   ac_cv_prog_cc_works=yes


### PR DESCRIPTION
This commit changes a test program used for checking if the C compiler works during configuration from `main(){return(0);}` to `int main(){return(0);}`, because GCC 14 no longer allows implicit return type from main